### PR TITLE
feat(config): add dictionary initializer to configuration

### DIFF
--- a/Sources/PianoAnalytics/Configuration.swift
+++ b/Sources/PianoAnalytics/Configuration.swift
@@ -80,6 +80,82 @@ public final class ConfigurationBuilder {
 
     }
 
+    /// Initializes a configuration builder using a key-value dictionary. Invalid keys or values are ignored.
+    ///
+    /// - Parameter parameters: the list of keys and values to set
+    public init(parameters: [String:Any]) {
+        for (rawKey, rawValue) in parameters {
+            guard let key = ConfigurationKey(rawValue: rawKey) else {
+                continue
+            }
+            switch key {
+                case .CollectDomain:
+                    let stringValue = rawValue as? String ?? String(describing: rawValue)
+                    _ = self.withCollectDomain(stringValue)
+                case .CrashDetection:
+                    if let boolValue = rawValue as? Bool ?? Bool(String(describing: rawValue)) {
+                        _ = self.enableCrashDetection(boolValue)
+                    }
+                case .CustomUserAgent:
+                    let stringValue = rawValue as? String ?? String(describing: rawValue)
+                    _ = self.withCustomUserAgent(stringValue)
+                case .PrivacyDefaultMode:
+                    let stringValue = rawValue as? String ?? String(describing: rawValue)
+                    _ = self.withPrivacyDefaultMode(stringValue)
+                case .IgnoreLimitedAdTracking:
+                    if let boolValue = rawValue as? Bool ?? Bool(String(describing: rawValue)) {
+                        _ = self.enableIgnoreLimitedAdTracking(boolValue)
+                    }
+                case .OfflineEncryptionMode:
+                    let stringValue = rawValue as? String ?? String(describing: rawValue)
+                    _ = self.withOfflineEncryptionMode(stringValue)
+                case .OfflineSendInterval:
+                    if let intValue = rawValue as? Int ?? Int(String(describing: rawValue)) {
+                        _ = self.withOfflineSendInterval(intValue)
+                    }
+                case .OfflineStorageMode:
+                    let stringValue = rawValue as? String ?? String(describing: rawValue)
+                    _ = self.withOfflineStorageMode(stringValue)
+                case .Path:
+                    let stringValue = rawValue as? String ?? String(describing: rawValue)
+                    _ = self.withPath(stringValue)
+                case .SendEventWhenOptout:
+                    if let boolValue = rawValue as? Bool ?? Bool(String(describing: rawValue)) {
+                        _ = self.enableSendEventWhenOptout(boolValue)
+                    }
+                case .SessionBackgroundDuration:
+                    if let intValue = rawValue as? Int ?? Int(String(describing: rawValue)) {
+                        _ = self.withSessionBackgroundDuration(intValue)
+                    }
+                case .Site:
+                    if let intValue = rawValue as? Int ?? Int(String(describing: rawValue)) {
+                        _ = self.withSite(intValue)
+                    }
+                case .StorageLifetimePrivacy:
+                    if let intValue = rawValue as? Int ?? Int(String(describing: rawValue)) {
+                        _ = self.withStorageLifetimePrivacy(intValue)
+                    }
+                case .StorageLifetimeUser:
+                    if let intValue = rawValue as? Int ?? Int(String(describing: rawValue)) {
+                        _ = self.withStorageLifetimeUser(intValue)
+                    }
+                case .StorageLifetimeVisitor:
+                    if let intValue = rawValue as? Int ?? Int(String(describing: rawValue)) {
+                        _ = self.withStorageLifetimeVisitor(intValue)
+                    }
+                case .VisitorStorageMode:
+                    let stringValue = rawValue as? String ?? String(describing: rawValue)
+                    _ = self.withVisitorStorageMode(stringValue)
+                case .VisitorIdType:
+                    let stringValue = rawValue as? String ?? String(describing: rawValue)
+                    _ = self.withVisitorIdType(stringValue)
+                case .VisitorId:
+                    let stringValue = rawValue as? String ?? String(describing: rawValue)
+                    _ = self.withVisitorID(stringValue)
+            }
+        }
+    }
+
     // MARK: PUBLIC SECTION
 
     /// Set a new collect endpoint to send your tagging data


### PR DESCRIPTION
## Description
Adds a new initializer to the `ConfigurationBuilder` class.  By taking a `[String:Any]` dictionary, this initializer is useful for configuring the SDK from a JSON file or remote JSON configuration.

Usage of a switch on the keys enum guaranties that if a new key is added, the initializer will need to be updated in order to compile.

## API Change

This is a purely additive change to the public API.


## Alternatives

This could also be written as `withParameters(_ parameters: [String:Any]) -> ConfigurationBuilder` method.