### PR TITLE
make init public and remove singleton

### DIFF
--- a/Sources/PianoAnalytics/PianoAnalytics.swift
+++ b/Sources/PianoAnalytics/PianoAnalytics.swift
@@ -25,8 +25,6 @@
 
 import Foundation
 
-public let pa = PianoAnalytics.shared
-
 public protocol PianoAnalyticsWorkProtocol {
     /// Called when raw data is available and customer want to override it before building
     ///
@@ -420,24 +418,13 @@ public final class PianoAnalytics {
 
     // MARK: Constructors
 
-    private static var _instance: PianoAnalytics?
-
-    /// Simple default init
-    public static let shared: PianoAnalytics = sharedWithConfigurationFilePath(ConfigFile)
-
-    /// Specific init with custom location configuration file
-    ///
-    /// - Parameter configFileLocation: file path from resources folder
-    public static let sharedWithConfigurationFilePath: (String) -> PianoAnalytics = { configFileLocation in
-        if _instance == nil {
-            _instance = PianoAnalytics(configFileLocation: configFileLocation)
-        }
-        return _instance ?? PianoAnalytics(configFileLocation: configFileLocation)
-    }
-
     internal final let queue: WorkingQueue
 
-    init(configFileLocation: String) {
+		public init() {
+				self.queue = WorkingQueue(Self.ConfigFile)
+		}
+
+    public init(configFileLocation: String) {
         self.queue = WorkingQueue(configFileLocation)
     }
 }

--- a/Tests/PianoAnalyticsTests/ConfigurationTests.swift
+++ b/Tests/PianoAnalyticsTests/ConfigurationTests.swift
@@ -63,7 +63,7 @@ class ConfigurationTests: XCTestCase {
     }
 
     func testDefaultConfigurationBuilderInit() throws {
-//        let configuration = ConfigurationBuilder().build()
+				let pa = PianoAnalytics()
         let expectation = self.expectation(description: "Configuration")
         var defaultConfiguration: Configuration?
 

--- a/Tests/PianoAnalyticsTests/PrivacyTests.swift
+++ b/Tests/PianoAnalyticsTests/PrivacyTests.swift
@@ -265,7 +265,7 @@ class PrivacyTests: XCTestCase {
             "customprop3andmore2": "3a2"
         ])
     ]
-    var pa = PianoAnalytics.shared
+    var pa = PianoAnalytics()
 
     override func setUpWithError() throws {
         // Put setup code here. This method is called before the invocation of each test method in the class.

--- a/Tests/PianoAnalyticsTests/PropertiesTests.swift
+++ b/Tests/PianoAnalyticsTests/PropertiesTests.swift
@@ -49,7 +49,7 @@ class TestProtocol: PianoAnalyticsWorkProtocol {
 
 class PropertiesTests: XCTestCase {
 
-    var pa = PianoAnalytics.shared
+    var pa = PianoAnalytics()
 
     override func setUpWithError() throws {
         // Put setup code here. This method is called before the invocation of each test method in the class.

--- a/Tests/PianoAnalyticsTests/SendTests.swift
+++ b/Tests/PianoAnalyticsTests/SendTests.swift
@@ -49,7 +49,7 @@ class PianoAnalyticsCallbacks: PianoAnalyticsWorkProtocol {
 
 class SendTests: XCTestCase {
 
-    var pa = PianoAnalytics.shared
+    var pa = PianoAnalytics()
 
     override func setUpWithError() throws {
         // Put setup code here. This method is called before the invocation of each test method in the class.

--- a/Tests/PianoAnalyticsTests/UsersTests.swift
+++ b/Tests/PianoAnalyticsTests/UsersTests.swift
@@ -29,7 +29,7 @@ import XCTest
 
 class UsersTests: XCTestCase {
 
-    var pa = PianoAnalytics.shared
+    var pa = PianoAnalytics()
 
     override func setUpWithError() throws {
         // Put setup code here. This method is called before the invocation of each test method in the class.


### PR DESCRIPTION
Whether a `PianoAnalytics` singleton is created or not should be the responsibility of the framework consumer not the framework itself.