### PR TITLE
Fix: dispatch autoheartbeat timers, send offline event dispatch

### DIFF
--- a/Sources/PianoAnalytics/AVInsights/AVMedia.swift
+++ b/Sources/PianoAnalytics/AVInsights/AVMedia.swift
@@ -587,13 +587,14 @@ public final class AVMedia {
     }
     
     private func updateHeartbeat(previousDelay: Int, startTimerMillis: Int64, minHearbeatDuration: Int, heartbeatDurations: [Int:Int], selector: Selector) -> Int {
-            let minutesDelay = Int((Int64(Date().timeIntervalSince1970 * 1000) - startTimerMillis) / 60000)
-            let heartbeatDelay = max(heartbeatDurations[minutesDelay] ?? previousDelay, minHearbeatDuration)
-            
-            heartbeatTimer = Timer.scheduledTimer(timeInterval: TimeInterval(heartbeatDelay), target: self, selector: selector, userInfo: nil, repeats: false)
-        
-            return heartbeatDelay;
+        let minutesDelay = Int((Int64(Date().timeIntervalSince1970 * 1000) - startTimerMillis) / 60000)
+        let heartbeatDelay = max(heartbeatDurations[minutesDelay] ?? previousDelay, minHearbeatDuration)
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            self.heartbeatTimer = Timer.scheduledTimer(timeInterval: TimeInterval(heartbeatDelay), target: self, selector: selector, userInfo: nil, repeats: false)
         }
+        return heartbeatDelay
+    }
 
     private func createSeekStart(oldCursorPosition: Int, extraProps: [String: Any]?) -> Event {
         self.previousCursorPositionMillis = self.currentCursorPositionMillis

--- a/Sources/PianoAnalytics/AVInsights/AVMedia.swift
+++ b/Sources/PianoAnalytics/AVInsights/AVMedia.swift
@@ -77,13 +77,21 @@ public final class AVMedia {
 
             if self.autoHeartbeat {
                 let diffMin = Int((Int64(Date().timeIntervalSince1970 * 1000) - self.startSessionTimeMillis) / 60000)
-                if let duration = self.heartbeatDurations[diffMin] {
-                    heartbeatTimer = Timer.scheduledTimer(timeInterval: TimeInterval(duration), target: self, selector: #selector(self.processAutoHeartbeat), userInfo: nil, repeats: false)
-                } else {
-                    heartbeatTimer = Timer.scheduledTimer(timeInterval: TimeInterval(MinHeartbeatDuration), target: self, selector: #selector(self.processAutoHeartbeat), userInfo: nil, repeats: false)
-                }
+                let duration = self.heartbeatDurations[diffMin]
+                dispatchHeartbeatTimerOnMain(duration: duration, selector: #selector(self.processAutoHeartbeat))
             }
             _playbackSpeed = newValue
+        }
+    }
+
+    private func dispatchHeartbeatTimerOnMain(duration: Int?, selector: Selector) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            if let duration {
+                self.heartbeatTimer = Timer.scheduledTimer(timeInterval: TimeInterval(duration), target: self, selector: selector, userInfo: nil, repeats: false)
+            } else {
+                self.heartbeatTimer = Timer.scheduledTimer(timeInterval: TimeInterval(self.MinHeartbeatDuration), target: self, selector: selector, userInfo: nil, repeats: false)
+            }
         }
     }
 
@@ -286,11 +294,8 @@ public final class AVMedia {
                 if self.autoBufferHeartbeat {
                     self.bufferTimeMillis = self.bufferTimeMillis == 0 ? Int64(Date().timeIntervalSince1970 * 1000) : self.bufferTimeMillis
                     let diffMin = Int((Int64(Date().timeIntervalSince1970 * 1000) - self.bufferTimeMillis) / 60000)
-                    if let duration = self.bufferHeartbeatDurations[diffMin] {
-                        heartbeatTimer = Timer.scheduledTimer(timeInterval: TimeInterval(duration), target: self, selector: #selector(self.processAutoRebufferHeartbeat), userInfo: nil, repeats: false)
-                    } else {
-                        heartbeatTimer = Timer.scheduledTimer(timeInterval: TimeInterval(MinBufferHeartbeatDuration), target: self, selector: #selector(self.processAutoRebufferHeartbeat), userInfo: nil, repeats: false)
-                    }
+                    let duration = self.bufferHeartbeatDurations[diffMin]
+                    dispatchHeartbeatTimerOnMain(duration: duration, selector: #selector(self.processAutoRebufferHeartbeat))
                 }
                 self.pa.sendEvents([self.createEvent(name: "av.rebuffer.start", withOptions: true, extraProps: extraProps)], config: nil)
 
@@ -298,11 +303,8 @@ public final class AVMedia {
                 if self.autoBufferHeartbeat {
                     self.bufferTimeMillis = self.bufferTimeMillis == 0 ? Int64(Date().timeIntervalSince1970 * 1000) : self.bufferTimeMillis
                     let diffMin = Int((Int64(Date().timeIntervalSince1970 * 1000) - self.bufferTimeMillis) / 60000)
-                    if let duration = self.bufferHeartbeatDurations[diffMin] {
-                        heartbeatTimer = Timer.scheduledTimer(timeInterval: TimeInterval(duration), target: self, selector: #selector(self.processAutoBufferHeartbeat), userInfo: nil, repeats: false)
-                    } else {
-                        heartbeatTimer = Timer.scheduledTimer(timeInterval: TimeInterval(MinBufferHeartbeatDuration), target: self, selector: #selector(self.processAutoBufferHeartbeat), userInfo: nil, repeats: false)
-                    }
+                    let duration = self.bufferHeartbeatDurations[diffMin]
+                    dispatchHeartbeatTimerOnMain(duration: duration, selector: #selector(self.processAutoBufferHeartbeat))
                 }
                 self.pa.sendEvents([self.createEvent(name: "av.buffer.start", withOptions: true, extraProps: extraProps)], config: nil)
             }
@@ -326,11 +328,8 @@ public final class AVMedia {
             stopHeartbeatTimer()
             if self.autoHeartbeat {
                 let diffMin = Int((Int64(Date().timeIntervalSince1970 * 1000) - self.startSessionTimeMillis) / 60000)
-                if let duration = self.heartbeatDurations[diffMin] {
-                    heartbeatTimer = Timer.scheduledTimer(timeInterval: TimeInterval(duration), target: self, selector: #selector(self.processAutoHeartbeat), userInfo: nil, repeats: false)
-                } else {
-                    heartbeatTimer = Timer.scheduledTimer(timeInterval: TimeInterval(MinHeartbeatDuration), target: self, selector: #selector(self.processAutoHeartbeat), userInfo: nil, repeats: false)
-                }
+                let duration = self.heartbeatDurations[diffMin]
+                dispatchHeartbeatTimerOnMain(duration: duration, selector: #selector(self.processAutoHeartbeat))
             }
             self.pa.sendEvents([self.createEvent(name: "av.start", withOptions: true, extraProps: extraProps)], config: nil)
         }
@@ -351,11 +350,8 @@ public final class AVMedia {
             stopHeartbeatTimer()
             if self.autoHeartbeat {
                 let diffMin = Int((Int64(Date().timeIntervalSince1970 * 1000) - self.startSessionTimeMillis) / 60000)
-                if let duration = self.heartbeatDurations[diffMin] {
-                    heartbeatTimer = Timer.scheduledTimer(timeInterval: TimeInterval(duration), target: self, selector: #selector(self.processAutoHeartbeat), userInfo: nil, repeats: false)
-                } else {
-                    heartbeatTimer = Timer.scheduledTimer(timeInterval: TimeInterval(MinHeartbeatDuration), target: self, selector: #selector(self.processAutoHeartbeat), userInfo: nil, repeats: false)
-                }
+                let duration = self.heartbeatDurations[diffMin]
+                dispatchHeartbeatTimerOnMain(duration: duration, selector: #selector(self.processAutoHeartbeat))
             }
             self.pa.sendEvents([self.createEvent(name: "av.resume", withOptions: true, extraProps: extraProps)], config: nil)
         }
@@ -520,11 +516,10 @@ public final class AVMedia {
             self.currentCursorPositionMillis += Int(Double(self.eventDurationMillis) * self._playbackSpeed)
 
             let diffMin = Int((Int64(Date().timeIntervalSince1970 * 1000) - self.startSessionTimeMillis) / 60000)
-            if let duration = self.heartbeatDurations[diffMin] {
-                heartbeatTimer = Timer.scheduledTimer(timeInterval: TimeInterval(duration), target: self, selector: #selector(self.processAutoHeartbeat), userInfo: nil, repeats: false)
-            } else {
-                heartbeatTimer = Timer.scheduledTimer(timeInterval: TimeInterval(MinHeartbeatDuration), target: self, selector: #selector(self.processAutoHeartbeat), userInfo: nil, repeats: false)
-            }
+
+            let duration = self.heartbeatDurations[diffMin]
+            dispatchHeartbeatTimerOnMain(duration: duration, selector: #selector(self.processAutoHeartbeat))
+
             self.pa.sendEvents([self.createEvent(name: "av.heartbeat", withOptions: true, extraProps: nil)], config: nil)
         }
     }
@@ -537,11 +532,9 @@ public final class AVMedia {
 
             self.bufferTimeMillis = self.bufferTimeMillis == 0 ? Int64(Date().timeIntervalSince1970 * 1000) : self.bufferTimeMillis
             let diffMin = Int((Int64(Date().timeIntervalSince1970 * 1000) - self.bufferTimeMillis) / 60000)
-            if let duration = self.bufferHeartbeatDurations[diffMin] {
-                heartbeatTimer = Timer.scheduledTimer(timeInterval: TimeInterval(duration), target: self, selector: #selector(self.processAutoBufferHeartbeat), userInfo: nil, repeats: false)
-            } else {
-                heartbeatTimer = Timer.scheduledTimer(timeInterval: TimeInterval(MinBufferHeartbeatDuration), target: self, selector: #selector(self.processAutoBufferHeartbeat), userInfo: nil, repeats: false)
-            }
+            let duration = self.bufferHeartbeatDurations[diffMin]
+            dispatchHeartbeatTimerOnMain(duration: duration, selector: #selector(self.processAutoBufferHeartbeat))
+
             self.pa.sendEvents([self.createEvent(name: "av.buffer.heartbeat", withOptions: true, extraProps: nil)], config: nil)
         }
     }
@@ -556,11 +549,9 @@ public final class AVMedia {
 
             self.bufferTimeMillis = self.bufferTimeMillis == 0 ? Int64(Date().timeIntervalSince1970 * 1000) : self.bufferTimeMillis
             let diffMin = Int((Int64(Date().timeIntervalSince1970 * 1000) - self.bufferTimeMillis) / 60000)
-            if let duration = self.bufferHeartbeatDurations[diffMin] {
-                heartbeatTimer = Timer.scheduledTimer(timeInterval: TimeInterval(duration), target: self, selector: #selector(self.processAutoRebufferHeartbeat), userInfo: nil, repeats: false)
-            } else {
-                heartbeatTimer = Timer.scheduledTimer(timeInterval: TimeInterval(MinBufferHeartbeatDuration), target: self, selector: #selector(self.processAutoRebufferHeartbeat), userInfo: nil, repeats: false)
-            }
+            let duration = self.bufferHeartbeatDurations[diffMin]
+            dispatchHeartbeatTimerOnMain(duration: duration, selector: #selector(self.processAutoRebufferHeartbeat))
+
             self.pa.sendEvents([self.createEvent(name: "av.rebuffer.heartbeat", withOptions: true, extraProps: nil)], config: nil)
         }
     }

--- a/Sources/PianoAnalytics/Steps/SendStep.swift
+++ b/Sources/PianoAnalytics/Steps/SendStep.swift
@@ -58,7 +58,8 @@ final class SendStep: Step {
     private final func sendStoredChunk(data: BuiltModel, userAgent: String, key: String) {
         self.send(data, userAgent: userAgent)
         do {
-            if let url = URL(string: key), FileManager.default.fileExists(atPath: key) {
+            if let url = URL(string: key),
+               FileManager.default.fileExists(atPath: key.replacingOccurrences(of: "file://", with: "")) {
                 try FileManager.default.removeItem(at: url)
             }
         } catch {

--- a/Sources/PianoAnalytics/Steps/SendStep.swift
+++ b/Sources/PianoAnalytics/Steps/SendStep.swift
@@ -56,12 +56,16 @@ final class SendStep: Step {
     }
 
     private final func sendStoredChunk(data: BuiltModel, userAgent: String, key: String) {
+        let fileManager = FileManager.default
+
+        guard fileManager.fileExists(atPath: key.replacingOccurrences(of: "file://", with: "")),
+              let url = URL(string: key) else {
+            return
+        }
         self.send(data, userAgent: userAgent)
+
         do {
-            if let url = URL(string: key),
-               FileManager.default.fileExists(atPath: key.replacingOccurrences(of: "file://", with: "")) {
-                try FileManager.default.removeItem(at: url)
-            }
+            try FileManager.default.removeItem(at: url)
         } catch {
             print("PianoAnalytics: error on SendStep.sendStoredData: \(error)")
         }


### PR DESCRIPTION
This PR fixes 

- an issue where timers were not dispatched on the main queue, such that no heartbeat events were fired at all
- an issue where offline events were processed on the main queue (kinda unperformant because of the semaphore semantics when sending the event)
- log warnings where the FileManager tried to delete non-existing files